### PR TITLE
Removed print statement to better support AutoPkg's --report-plist optio...

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -104,8 +104,10 @@ class JSSImporter(Processor):
         # build our request for the entire list of items
         if apiUrl[-1] == "y":
             submitRequest = urllib2.Request(repoUrl + "/JSSResource/" + apiUrl[:-1] + "ies")
+            self.output('Trying to reach JSS and fetch all %s at URL %s' % (apiUrl[:-1] + "ies", repoUrl))
         else:
             submitRequest = urllib2.Request(repoUrl + "/JSSResource/" + apiUrl + "s")
+            self.output('Trying to reach JSS and fetch all %s at URL %s' % (apiUrl + "s", repoUrl))
         submitRequest.add_header("Authorization", "Basic %s" % base64string)
         # try reaching the server and performing the GET
         try:


### PR DESCRIPTION
...n. Also cleaned up to conform (somethat) to PEP8.

This PR should address issues when using JSS recipes with AutoPkg's --report-plist option, since the "Trying to reach JSS..." messages won't be spewed to stdout, (which makes it difficult to parse the output plist).

For an example, see [this](https://gist.github.com/timsutton/7237350).
